### PR TITLE
Url fix

### DIFF
--- a/layouts/partials/base/imports.html
+++ b/layouts/partials/base/imports.html
@@ -1,4 +1,3 @@
-{{ $baseurl := .Site.BaseURL }}
 {{ "<!--[if lt IE 9]>" | safeHTML }}
 <script src="https://oss.maxcdn.com/libs/html5shiv/3.7.0/html5shiv.js"></script>
 <script src="https://oss.maxcdn.com/libs/respond.js/1.4.2/respond.min.js"></script>
@@ -6,5 +5,5 @@
 
 <link href='https://fonts.googleapis.com/css?family=Merriweather:300%7CRaleway%7COpen+Sans' rel='stylesheet' type='text/css'>
 <link rel="stylesheet" href="{{ "css/font-awesome.min.css" | relURL }}">
-<link rel="stylesheet" href="css/style.css">
+<link rel="stylesheet" href="{{ "css/style.css" | relURL }}">
 {{ if isset .Site.Params "highlight" }}<link rel="stylesheet" href="{{ "css/highlight/{{ .Site.Params.highlight }}.css" | relURL}}">{{ end }}

--- a/layouts/partials/base/imports.html
+++ b/layouts/partials/base/imports.html
@@ -4,6 +4,6 @@
 {{ "<![endif]-->" | safeHTML }}
 
 <link href='https://fonts.googleapis.com/css?family=Merriweather:300%7CRaleway%7COpen+Sans' rel='stylesheet' type='text/css'>
-<link rel="stylesheet" href="{{ "css/font-awesome.min.css" | relURL }}">
+<link rel="stylesheet" href="{{ "css/font-awesome.min.css" | absURL }}">
 <link rel="stylesheet" href="{{ "css/style.css" | relURL }}">
 {{ if isset .Site.Params "highlight" }}<link rel="stylesheet" href="{{ "css/highlight/{{ .Site.Params.highlight }}.css" | relURL}}">{{ end }}

--- a/layouts/partials/base/imports.html
+++ b/layouts/partials/base/imports.html
@@ -5,6 +5,6 @@
 {{ "<![endif]-->" | safeHTML }}
 
 <link href='https://fonts.googleapis.com/css?family=Merriweather:300%7CRaleway%7COpen+Sans' rel='stylesheet' type='text/css'>
-<link rel="stylesheet" href="{{ $baseurl }}css/font-awesome.min.css">
-<link rel="stylesheet" href="{{ $baseurl }}css/style.css">
-{{ if isset .Site.Params "highlight" }}<link rel="stylesheet" href="{{ $baseurl }}css/highlight/{{ .Site.Params.highlight }}.css">{{ end }}
+<link rel="stylesheet" href="{{ "css/font-awesome.min.css" | relURL }}">
+<link rel="stylesheet" href="css/style.css">
+{{ if isset .Site.Params "highlight" }}<link rel="stylesheet" href="{{ "css/highlight/{{ .Site.Params.highlight }}.css" | relURL}}">{{ end }}

--- a/layouts/partials/base/imports.html
+++ b/layouts/partials/base/imports.html
@@ -4,6 +4,6 @@
 {{ "<![endif]-->" | safeHTML }}
 
 <link href='https://fonts.googleapis.com/css?family=Merriweather:300%7CRaleway%7COpen+Sans' rel='stylesheet' type='text/css'>
-<link rel="stylesheet" href="{{ "css/font-awesome.min.css" | absURL }}">
+<link rel="stylesheet" href="{{ "css/font-awesome.min.css" | relURL }}">
 <link rel="stylesheet" href="{{ "css/style.css" | relURL }}">
 {{ if isset .Site.Params "highlight" }}<link rel="stylesheet" href="{{ "css/highlight/{{ .Site.Params.highlight }}.css" | relURL}}">{{ end }}

--- a/layouts/partials/base/scripts.html
+++ b/layouts/partials/base/scripts.html
@@ -1,4 +1,3 @@
-{{ $baseurl := .Site.BaseURL }}
 {{ with .Site.DisqusShortname }}
 <script type="text/javascript">
   (function() {
@@ -15,6 +14,6 @@
 {{ end }}
 
 {{ with .Site.Params.highlight }}
-<script src="{{ $baseurl }}js/highlight.pack.js"></script>
+<script src="{{ "js/highlight.pack.js" | relURL }}"></script>
 <script>hljs.initHighlightingOnLoad();</script>
 {{ end }}


### PR DESCRIPTION
Looking through https://github.com/gohugoio/hugo/issues/3262 it appears there was a commit that removed the baseURLs trailing slash which if you have baseURL like "https://mycoolsite" the CSS will be linked to https://mycoolsitecss/foo.css

It looks like the recommended is to use relURL